### PR TITLE
Remove unnecessary googleApiKey check

### DIFF
--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -42,11 +42,6 @@ Module.register('MMM-TeslaFi', {
 			wrapper.className = "dimmed light small";
 			return wrapper;
 		}
-		if (this.config.googleApiKey === "") {
-			wrapper.innerHTML = "No Google <i>api Key</i> set in config file.";
-			wrapper.className = "dimmed light small";
-			return wrapper;
-		}
 		if (!this.data) {
 			wrapper.innerHTML = "No data";
 			wrapper.className = "dimmed light small";


### PR DESCRIPTION
This check seems to have been copy/pasted with the initial creation of the module, as isn't needed