### PR TITLE
Resolve issues with time intervals

### DIFF
--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -66,6 +66,7 @@ Module.register("MMM-TeslaFi", {
     ];
   },
   start: function () {
+    Log.info("Starting module: " + this.name);
     this.loaded = false;
     this.sendSocketNotification("CONFIG", this.config);
 

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -422,6 +422,7 @@ Module.register("MMM-TeslaFi", {
       // If the node_helper socket has only just opened, refresh the DOM to make sure we're displaying a loading message
       this.updateDom();
     } else if (notification === "DATA") {
+      Log.info("TeslaFi recevied new data");
       // We've received data from TeslaFi, so parse and display it
       var data = JSON.parse(payload);
       if (!data) {

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -72,7 +72,7 @@ Module.register("MMM-TeslaFi", {
 
     // Refresh the DOM at the given interval
     var self = this;
-    this.domTimer = setTimeout(function () {
+    this.domTimer = setInterval(function () {
       self.updateDom(self.config.animationSpeed);
     }, this.config.refreshInterval);
   },

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -70,8 +70,13 @@ Module.register("MMM-TeslaFi", {
     this.loaded = false;
     this.sendSocketNotification("CONFIG", this.config);
 
-    // Refresh the DOM at the given interval
+    this.resetDomUpdate();
+  },
+  resetDomUpdate: function () {
     var self = this;
+    // Reset any previously allocated timer to avoid double-refreshes
+    clearInterval(this.domTimer);
+    // Refresh the DOM at the given interval
     this.domTimer = setInterval(function () {
       self.updateDom(self.config.animationSpeed);
     }, this.config.refreshInterval);
@@ -431,6 +436,7 @@ Module.register("MMM-TeslaFi", {
       this.data = data;
       this.loaded = true;
       this.updateDom(this.config.animationSpeed);
+      this.resetDomUpdate();
     }
   },
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can then use the various configuration options below to customise how the mo
 | Option           | Details                                                                                                               | Example                                             |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | apiKey           | **Required** - The API key from [TeslaFi.com](https://teslafi.com/api.php)                                            | `4de3736a68714869d3e2fbda1f1b83ff`                  |
+| refreshInterval  | The time interval (in milliseconds) at which the module contents will be updated locally                              | `1000 * 60`                                         |
+| updateInterval   | The time interval (in milliseconds) at which fresh data will be gathered from TeslaFi                                 | `1000 * 60 * 5`                                     |
 | batteryDanger    | The percentage below which your battery level will highlight in red                                                   | `40`                                                |
 | batteryWarning   | The percentage below which your battery level will highlight in orange                                                | `60`                                                |
 | precision        | How many decimal places to round values (such as mileage and energy) to. Defaults to 1                                | `2`                                                 |

--- a/node_helper.js
+++ b/node_helper.js
@@ -36,16 +36,15 @@ module.exports = NodeHelper.create({
 
     setTimeout(function () {
       self.getData();
-    }, this.config.refreshInterval);
+    }, this.config.updateInterval);
   },
 
   socketNotificationReceived: function (notification, payload) {
-    var self = this;
-    if (notification === "CONFIG" && self.started === false) {
-      self.config = payload;
-      self.sendSocketNotification("STARTED", true);
-      self.getData();
-      self.started = true;
+    if (notification === "CONFIG" && this.started === false) {
+      this.config = payload;
+      this.sendSocketNotification("STARTED", true);
+      this.getData();
+      this.started = true;
     }
   }
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -11,6 +11,7 @@
 
 const NodeHelper = require("node_helper");
 var request = require("request");
+const Log = require("../../js/logger");
 
 module.exports = NodeHelper.create({
   start: function () {
@@ -21,6 +22,7 @@ module.exports = NodeHelper.create({
   getData: function () {
     var self = this;
     var myUrl = this.config.apiBase + this.config.apiKey + this.config.apiQuery;
+    Log.info("TeslaFi sending request");
     request(
       {
         url: myUrl,
@@ -28,7 +30,9 @@ module.exports = NodeHelper.create({
         headers: { TeslaFi_API_TOKEN: this.config.apiKey }
       },
       function (error, response, body) {
+        Log.info("TeslaFi response was " + response.statusCode);
         if (!error && response.statusCode === 200) {
+          Log.info("TeslaFi sending data");
           self.sendSocketNotification("DATA", body);
         }
       }
@@ -41,6 +45,7 @@ module.exports = NodeHelper.create({
 
   socketNotificationReceived: function (notification, payload) {
     if (notification === "CONFIG" && this.started === false) {
+      Log.info("TeslaFi received configuration");
       this.config = payload;
       this.sendSocketNotification("STARTED", true);
       this.getData();


### PR DESCRIPTION
Fixes #23 

As described in #23, the module currently confuses `refreshInterval` and `updateInterval`. This PR properly documents what each one does, and applies this correctly within the module.

DOM refreshes and TeslaFi updates are now handled within entirely separate loops. I've chosen to make a data update instantly refresh the DOM - however this will result in 3 DOM refreshes within 60 seconds by the default configuration. Leaving this open to consider whether or not to reset the `domTimer` when fresh data arrives.