### PR TITLE
Split map configuration options

### DIFF
--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -7,13 +7,9 @@
  */
 Module.register("MMM-TeslaFi", {
   defaults: {
-    units: config.units,
     animationSpeed: 1000,
     refreshInterval: 1000 * 60, // Refresh DOM every 60 seconds
     updateInterval: 1000 * 60 * 5, // Load TeslaFi data every 5 minutes
-    lang: config.language,
-    initialLoadDelay: 0, // 0 seconds delay
-    retryDelay: 2500,
     unitDistance: "miles",
     unitTemperature: "c",
     batteryDanger: 30,
@@ -26,9 +22,6 @@ Module.register("MMM-TeslaFi", {
       zoom: 13,
       exclude: []
     },
-    homeAddress: "",
-    googleApiBase:
-      "https://maps.googleapis.com/maps/api/distancematrix/json?key=",
     precision: 1, // How many decimal places to round values to
     apiBase: "https://www.teslafi.com/feed.php?token=",
     apiQuery: "&command=lastGood",

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -19,11 +19,13 @@ Module.register("MMM-TeslaFi", {
     batteryDanger: 30,
     batteryWarning: 50,
     dataTimeout: 0,
-    googleMapApiKey: "",
-    mapZoom: 13,
-    mapWidth: 300,
-    mapHeight: 150,
-    excludeLocations: [],
+    maps: {
+      apiKey: "",
+      width: 300,
+      height: 150,
+      zoom: 13,
+      exclude: []
+    },
     homeAddress: "",
     googleApiBase:
       "https://maps.googleapis.com/maps/api/distancematrix/json?key=",

--- a/README.md
+++ b/README.md
@@ -51,13 +51,20 @@ You can then use the various configuration options below to customise how the mo
 | items            | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
 | initialLoadDelay | How many seconds to delay initial API call                                                                            | `10`                                                |
 | dataTimeout      | How old data must be in seconds before 'data-time' is displayed. Use 0 to always show                                 | `0`                                                 |
-| **maps**         | Group of configuration values relating to displaying vehicle location on a Google Map                                 |                                                     |
-| maps.apiKey      | Google Maps API key. Must have "Static Maps API" access enabled. See [Map](#map) below for more detail                | `AIzaSyB6KgHKwRNa63JsVHuu7d8jV-1IH875idKs`          |
-| maps.zoom        | [Zoom level](https://developers.google.com/maps/documentation/maps-static/start#Zoomlevels) of map                    | `13`                                                |
-| maps.width       | Specify width of map                                                                                                  | `300`                                               |
-| maps.height      | Specify height of map                                                                                                 | `150`                                               |
-| maps.exclude     | Specify TeslaFi tagged locations at which the map field will not be shown. Case insensitive.                          | `[ 'home', 'Work', 'cottage' ]`                     |
-| maps.drivingOnly | Only display the map when the car is driving                                                                          | `true`                                              |
+
+### Maps Configuration
+
+The `maps` configuration option takes the following sub-options, which allow you to configure a static Google Maps display of the vehicles current location.
+See [Map section](#map) below for more information
+
+| Option           | Details                                                                                                | Example                                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| maps.apiKey      | Google Maps API key. Must have "Static Maps API" access enabled. See [Map](#map) below for more detail | `AIzaSyB6KgHKwRNa63JsVHuu7d8jV-1IH875idKs` |
+| maps.zoom        | [Zoom level](https://developers.google.com/maps/documentation/maps-static/start#Zoomlevels) of map     | `13`                                       |
+| maps.width       | Specify width of map                                                                                   | `300`                                      |
+| maps.height      | Specify height of map                                                                                  | `150`                                      |
+| maps.exclude     | Specify TeslaFi tagged locations at which the map field will not be shown. Case insensitive.           | `[ 'home', 'Work', 'cottage' ]`            |
+| maps.drivingOnly | Only display the map when the car is driving                                                           | `true`                                     |
 
 ## Available fields
 
@@ -91,7 +98,26 @@ You can then use the various configuration options below to customise how the mo
 
 In order to enable the `map` field, you must first have created a Google Maps API key from the [Google Maps Developer Platform](https://developers.google.com/maps/documentation/maps-static/overview). This is easy to do, and comes
 with ~100,000 free calls per month. Once you have created the API key, you must enable the "Maps Static API". Once you have done this, add the API key to your configuration and add the `map` field to your list of items.
-This will show a non-interactive map of the vehicles location. The size of this map can be configured with the `mapZoom`,`mapWidth` and `mapHeight` configuration options. Note that you will not be able to zoom or move the map with touch/mouse functionality.
+This will show a non-interactive map of the vehicles location. The size of this map can be configured with the `maps` configuration options, as in the example below. Note that you will not be able to zoom or move the map with touch/mouse functionality.
+
+```
+modules: [
+  {
+    module: "MMM-TeslaFi",
+    position: "top_left",
+    config: {
+      apiKey: "ENTER YOUR TESLAFI KEY HERE",
+      maps: {
+        apiKey: "ENTER YOUR GOOGLE MAPS KEY HERE",
+        zoom: 12,
+        width: 300,
+        height: 300,
+        drivingOnly: true
+      }
+    }
+  }
+];
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ You can then use the various configuration options below to customise how the mo
 | items            | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
 | initialLoadDelay | How many seconds to delay initial API call                                                                            | `10`                                                |
 | dataTimeout      | How old data must be in seconds before 'data-time' is displayed. Use 0 to always show                                 | `0`                                                 |
-| googleMapApiKey  | Google Maps API key. Must have "Static Maps API" access enabled. See [Map](#map) below for more detail                | `AIzaSyB6KgHKwRNa63JsVHuu7d8jV-1IH875idKs`          |
-| mapZoom          | [Zoom level](https://developers.google.com/maps/documentation/maps-static/start#Zoomlevels) of map                    | `13`                                                |
-| mapWidth         | Specify width of map                                                                                                  | `300`                                               |
-| mapHeight        | Specify height of map                                                                                                 | `150`                                               |
-| excludeLocations | Specify TeslaFi tagged locations at which the map field will not be shown. Case insensitive.                          | `[ 'home', 'Work', 'cottage' ]`                     |
+| **maps**         | Group of configuration values relating to displaying vehicle location on a Google Map                                 |
+| maps.apiKey      | Google Maps API key. Must have "Static Maps API" access enabled. See [Map](#map) below for more detail                | `AIzaSyB6KgHKwRNa63JsVHuu7d8jV-1IH875idKs`          |
+| maps.zoom        | [Zoom level](https://developers.google.com/maps/documentation/maps-static/start#Zoomlevels) of map                    | `13`                                                |
+| maps.width       | Specify width of map                                                                                                  | `300`                                               |
+| maps.height      | Specify height of map                                                                                                 | `150`                                               |
+| maps.exclude     | Specify TeslaFi tagged locations at which the map field will not be shown. Case insensitive.                          | `[ 'home', 'Work', 'cottage' ]`                     |
 
 ## Available fields
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can then use the various configuration options below to customise how the mo
 | items            | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
 | initialLoadDelay | How many seconds to delay initial API call                                                                            | `10`                                                |
 | dataTimeout      | How old data must be in seconds before 'data-time' is displayed. Use 0 to always show                                 | `0`                                                 |
-| **maps**         | Group of configuration values relating to displaying vehicle location on a Google Map                                 |
+| **maps**         | Group of configuration values relating to displaying vehicle location on a Google Map                                 |                                                     |
 | maps.apiKey      | Google Maps API key. Must have "Static Maps API" access enabled. See [Map](#map) below for more detail                | `AIzaSyB6KgHKwRNa63JsVHuu7d8jV-1IH875idKs`          |
 | maps.zoom        | [Zoom level](https://developers.google.com/maps/documentation/maps-static/start#Zoomlevels) of map                    | `13`                                                |
 | maps.width       | Specify width of map                                                                                                  | `300`                                               |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [Map section](#map) below for more information
 | state                  | Vehicle State (Idling/Driving/Sentry)                                                                                            |
 | speed                  | Vehicle speed in preferred units                                                                                                 |
 | heading                | Vehicle heading                                                                                                                  |
-| map                    | Displays current location on a map - Dims if not 'Driving'. See the [Map section](#map) for details on how to configure          |
+| map                    | Displays current location on a map. See the [Map section](#map) for details on how to configure                                  |
 
 - Some fields (charge-time, charge-added, charge-power) are only enabled if the vehicle is plugged in
 - Some fields (version, speed, heading) are only enabled if the vehicle is not driving

--- a/README.md
+++ b/README.md
@@ -36,21 +36,20 @@ You can then use the various configuration options below to customise how the mo
 
 ## Config Options
 
-| Option           | Details                                                                                                               | Example                                             |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| apiKey           | **Required** - The API key from [TeslaFi.com](https://teslafi.com/api.php)                                            | `4de3736a68714869d3e2fbda1f1b83ff`                  |
-| refreshInterval  | The time interval (in milliseconds) at which the module contents will be updated locally                              | `1000 * 60`                                         |
-| updateInterval   | The time interval (in milliseconds) at which fresh data will be gathered from TeslaFi                                 | `1000 * 60 * 5`                                     |
-| batteryDanger    | The percentage below which your battery level will highlight in red                                                   | `40`                                                |
-| batteryWarning   | The percentage below which your battery level will highlight in orange                                                | `60`                                                |
-| precision        | How many decimal places to round values (such as mileage and energy) to. Defaults to 1                                | `2`                                                 |
-| apiBase          | The URL to use for the TeslaFi API                                                                                    | `https://www.teslafi.com/feed.php?token=`           |
-| apiQuery         | Extra parameters to add on to the end of the TeslaFi API call                                                         | `&command=lastGoodTemp`                             |
-| unitTemperature  | The unit to use for displaying temperature. Options are 'f' (Farenheight) or 'c' (Celcius). Defaults to 'c'           | `f`                                                 |
-| unitDistance     | The unit to use for displaying distance. Options are 'miles' or 'km'. Defaults to 'miles'                             | `km`                                                |
-| items            | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
-| initialLoadDelay | How many seconds to delay initial API call                                                                            | `10`                                                |
-| dataTimeout      | How old data must be in seconds before 'data-time' is displayed. Use 0 to always show                                 | `0`                                                 |
+| Option          | Details                                                                                                               | Example                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| apiKey          | **Required** - The API key from [TeslaFi.com](https://teslafi.com/api.php)                                            | `4de3736a68714869d3e2fbda1f1b83ff`                  |
+| refreshInterval | The time interval (in milliseconds) at which the module contents will be updated locally                              | `1000 * 60`                                         |
+| updateInterval  | The time interval (in milliseconds) at which fresh data will be gathered from TeslaFi                                 | `1000 * 60 * 5`                                     |
+| batteryDanger   | The percentage below which your battery level will highlight in red                                                   | `40`                                                |
+| batteryWarning  | The percentage below which your battery level will highlight in orange                                                | `60`                                                |
+| precision       | How many decimal places to round values (such as mileage and energy) to. Defaults to 1                                | `2`                                                 |
+| apiBase         | The URL to use for the TeslaFi API                                                                                    | `https://www.teslafi.com/feed.php?token=`           |
+| apiQuery        | Extra parameters to add on to the end of the TeslaFi API call                                                         | `&command=lastGoodTemp`                             |
+| unitTemperature | The unit to use for displaying temperature. Options are 'f' (Farenheight) or 'c' (Celcius). Defaults to 'c'           | `f`                                                 |
+| unitDistance    | The unit to use for displaying distance. Options are 'miles' or 'km'. Defaults to 'miles'                             | `km`                                                |
+| items           | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
+| dataTimeout     | How old data must be in seconds before 'data-time' is displayed. Use 0 to always show                                 | `0`                                                 |
 
 ### Maps Configuration
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can then use the various configuration options below to customise how the mo
 | maps.width       | Specify width of map                                                                                                  | `300`                                               |
 | maps.height      | Specify height of map                                                                                                 | `150`                                               |
 | maps.exclude     | Specify TeslaFi tagged locations at which the map field will not be shown. Case insensitive.                          | `[ 'home', 'Work', 'cottage' ]`                     |
+| maps.drivingOnly | Only display the map when the car is driving                                                                          | `true`                                              |
 
 ## Available fields
 

--- a/dataitems/location.js
+++ b/dataitems/location.js
@@ -8,6 +8,15 @@
  */
 DataItemProvider.register("map", {
   onDataUpdate(data) {
+    this.height = this.setParam(this.config.maps.height, "number", 150);
+    this.width = this.setParam(this.config.maps.width, "number", 300);
+    this.zoom = this.setParam(this.config.maps.zoom, "number", 13);
+    this.drivingOnly = this.setParam(
+      this.config.maps.drivingOnly,
+      "boolean",
+      false
+    );
+
     if (!this.hasApiKey()) {
       this.display = true;
       this.icon = `<span class="zmdi zmdi-alert-octagon sentry zmdi-hc-fw"></span>`;
@@ -16,7 +25,12 @@ DataItemProvider.register("map", {
       return;
     }
 
-    if (this.isExcluded(data.location) || data.carState !== "Driving") {
+    if (this.drivingOnly && data.carState !== "Driving") {
+      this.display = false;
+      return;
+    }
+
+    if (this.isExcluded(data.location)) {
       this.display = false;
       return;
     }
@@ -24,6 +38,15 @@ DataItemProvider.register("map", {
     this.display = true;
     var url = this.getMap(data.latitude, data.longitude);
     this.icon = `<img alt="map" class="map" src="${url}" />`;
+  },
+
+  // Check that our config value is of the correct type, otherwise set the default
+  setParam: function (variable, expectedType, def) {
+    if (typeof variable === expectedType) {
+      return variable;
+    } else {
+      return def;
+    }
   },
 
   isExcluded: function (locale) {
@@ -48,11 +71,11 @@ DataItemProvider.register("map", {
     if (this.hasApiKey()) {
       const options = {
         center: [lat, lng],
-        zoom: this.config.maps.zoom,
+        zoom: this.zoom,
         key: this.config.maps.apiKey,
         marker: [lat, lng]
       };
-      return `https://maps.googleapis.com/maps/api/staticmap?size=${this.config.maps.width}x${this.config.maps.height}&center=${options.center}&markers=${options.marker}&key=${options.key}&zoom=${options.zoom}&size=tiny`;
+      return `https://maps.googleapis.com/maps/api/staticmap?size=${this.width}x${this.height}&center=${options.center}&markers=${options.marker}&key=${options.key}&zoom=${options.zoom}&size=tiny`;
     }
   }
 });

--- a/dataitems/location.js
+++ b/dataitems/location.js
@@ -1,6 +1,6 @@
 /*
  * Display the current location of the vehicle within a static Google Maps window
- * Size of the map can be modified using the `mapZoom`, `mapWidth` and `mapHeight` configuration options
+ * Size of the map can be modified using the `maps.zoom`, `maps.width` and `maps.height` configuration options
  * Requires a valid Google Maps API key - see the README for more information
  *
  * Created by Matt Dyson
@@ -8,7 +8,8 @@
  */
 DataItemProvider.register("map", {
   onDataUpdate(data) {
-    if (this.config.googleMapApiKey === "") {
+    if (!this.hasApiKey()) {
+      this.display = true;
       this.icon = `<span class="zmdi zmdi-alert-octagon sentry zmdi-hc-fw"></span>`;
       this.field = "MAP ERROR!";
       this.value = "Missing Google Maps API Key";
@@ -26,21 +27,32 @@ DataItemProvider.register("map", {
   },
 
   isExcluded: function (locale) {
-    const excludeLocationsUpper = this.config.excludeLocations.map((location) =>
+    if (typeof this.config.maps.exclude !== "object") {
+      return false;
+    }
+
+    const excludeLocationsUpper = this.config.maps.exclude.map((location) =>
       location.toUpperCase()
     );
     return excludeLocationsUpper.includes(locale.toUpperCase());
   },
 
+  hasApiKey: function () {
+    return (
+      typeof this.config.maps.apiKey === "string" &&
+      this.config.maps.apiKey !== ""
+    );
+  },
+
   getMap: function (lat, lng) {
-    if (this.config.googleMapApiKey !== "") {
+    if (this.hasApiKey()) {
       const options = {
         center: [lat, lng],
-        zoom: this.config.mapZoom,
-        key: this.config.googleMapApiKey,
+        zoom: this.config.maps.zoom,
+        key: this.config.maps.apiKey,
         marker: [lat, lng]
       };
-      return `https://maps.googleapis.com/maps/api/staticmap?size=${this.config.mapWidth}x${this.config.mapHeight}&center=${options.center}&markers=${options.marker}&key=${options.key}&zoom=${options.zoom}&size=tiny`;
+      return `https://maps.googleapis.com/maps/api/staticmap?size=${this.config.maps.width}x${this.config.maps.height}&center=${options.center}&markers=${options.marker}&key=${options.key}&zoom=${options.zoom}&size=tiny`;
     }
   }
 });


### PR DESCRIPTION
Fixes #26 

Move all map configuration options in to separate sub-option for better clarity. I've chosen not to move other options in to sub-fields at this point as I think this one does enough tidying up for now!

Needs one final glance over to remove unused configuration options which have crept in