### PR TITLE
Migrate to using URL-Builder

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "es2021": true
   },
   "globals": {
+    "buildUrl": true,
     "config": true,
     "DataItemProvider": true,
     "Log": true,

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -23,8 +23,7 @@ Module.register("MMM-TeslaFi", {
       exclude: []
     },
     precision: 1, // How many decimal places to round values to
-    apiBase: "https://www.teslafi.com/feed.php?token=",
-    apiQuery: "&command=lastGood",
+    apiCommand: "lastGood",
     items: [
       "state",
       "speed",

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -51,6 +51,7 @@ Module.register("MMM-TeslaFi", {
     return [
       "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js",
       "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js",
+      this.file("node_modules/build-url/src/build-url.js"),
       "moment.js",
       this.file("DataItemProvider.js"),
       this.file("dataitems/battery.js"),

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ I am happy to accept any [bug reports](https://github.com/mattdy/MMM-TeslaFi/iss
 
 Open a terminal session, navigate to your MagicMirror's `modules` folder and execute the following commands:
 ```console
-git clone https://github.com/mattdy/MMM-TeslaFi.git
-cd MMM-TeslaFi
-npm install
+$ git clone https://github.com/mattdy/MMM-TeslaFi.git
+$ cd MMM-TeslaFi
+$ npm install
 ```
 
 Alternatively, you can install automatically using the excellent [Magic Mirror Package Manager](https://github.com/Bee-Mar/mmpm)
 ```console
-mmpm -i MMM-TeslaFi
+$ mmpm -i MMM-TeslaFi
 ```
 
 Once installed, you should then activate the module by adding it to the config.js file as shown here:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ I am happy to accept any [bug reports](https://github.com/mattdy/MMM-TeslaFi/iss
 ## Installation
 
 Open a terminal session, navigate to your MagicMirror's `modules` folder and execute the following commands:
+
 ```console
 $ git clone https://github.com/mattdy/MMM-TeslaFi.git
 $ cd MMM-TeslaFi
@@ -23,11 +24,13 @@ $ npm install
 ```
 
 Alternatively, you can install automatically using the excellent [Magic Mirror Package Manager](https://github.com/Bee-Mar/mmpm)
+
 ```console
 $ mmpm -i MMM-TeslaFi
 ```
 
 Once installed, you should then activate the module by adding it to the config.js file as shown here:
+
 ```javascript
 modules: [
   {

--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ I am happy to accept any [bug reports](https://github.com/mattdy/MMM-TeslaFi/iss
 
 ## Installation
 
-Open a terminal session, navigate to your MagicMirror's `modules` folder and execute `git clone https://github.com/mattdy/MMM-TeslaFi.git`, a new folder called MMM-TeslaFi will be created.
+Open a terminal session, navigate to your MagicMirror's `modules` folder and execute the following commands:
+```console
+git clone https://github.com/mattdy/MMM-TeslaFi.git
+cd MMM-TeslaFi
+npm install
+```
 
-Activate the module by adding it to the config.js file as shown here:
+Alternatively, you can install automatically using the excellent [Magic Mirror Package Manager](https://github.com/Bee-Mar/mmpm)
+```console
+mmpm -i MMM-TeslaFi
+```
 
+Once installed, you should then activate the module by adding it to the config.js file as shown here:
 ```javascript
 modules: [
   {

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ You can then use the various configuration options below to customise how the mo
 | batteryDanger   | The percentage below which your battery level will highlight in red                                                   | `40`                                                |
 | batteryWarning  | The percentage below which your battery level will highlight in orange                                                | `60`                                                |
 | precision       | How many decimal places to round values (such as mileage and energy) to. Defaults to 1                                | `2`                                                 |
-| apiBase         | The URL to use for the TeslaFi API                                                                                    | `https://www.teslafi.com/feed.php?token=`           |
-| apiQuery        | Extra parameters to add on to the end of the TeslaFi API call                                                         | `&command=lastGoodTemp`                             |
+| apiCommand      | The command parameter for the TeslaFi API query. See [TeslaFi](https://teslafi.com/api.php) for possible values       | `lastGoodTemp`                                      |
 | unitTemperature | The unit to use for displaying temperature. Options are 'f' (Farenheight) or 'c' (Celcius). Defaults to 'c'           | `f`                                                 |
 | unitDistance    | The unit to use for displaying distance. Options are 'miles' or 'km'. Defaults to 'miles'                             | `km`                                                |
 | items           | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
@@ -99,7 +98,7 @@ See [Map section](#map) below for more information
 
 - Some fields (charge-time, charge-added, charge-power) are only enabled if the vehicle is plugged in
 - Some fields (version, speed, heading) are only enabled if the vehicle is not driving
-- The temperature field may not be populated if you use TeslaFi's sleep mode, which will stop this row from showing entirely. You may need to use `apiQuery: "&command=lastGoodTemp"` if this fails to show
+- The temperature field may not be populated if you use TeslaFi's sleep mode, which will stop this row from showing entirely. You may need to use `apiCommand: "lastGoodTemp"` if this fails to show
 - For details on TeslaFi's 'location' tags, see [TeslaFi Locations](https://teslafi.com/locations.php)
 
 ## Map

--- a/dataitems/location.js
+++ b/dataitems/location.js
@@ -68,15 +68,22 @@ DataItemProvider.register("map", {
   },
 
   getMap: function (lat, lng) {
-    if (this.hasApiKey()) {
-      const options = {
-        center: [lat, lng],
-        zoom: this.zoom,
-        key: this.config.maps.apiKey,
-        marker: [lat, lng]
-      };
-      return `https://maps.googleapis.com/maps/api/staticmap?size=${this.width}x${this.height}&center=${options.center}&markers=${options.marker}&key=${options.key}&zoom=${options.zoom}&size=tiny`;
+    if (!this.hasApiKey()) {
+      return "";
     }
+
+    var self = this;
+
+    return buildUrl("https://maps.googleapis.com", {
+      path: "maps/api/staticmap",
+      queryParams: {
+        size: self.width + "x" + self.height,
+        center: [lat, lng],
+        markers: [lat, lng],
+        key: self.config.maps.apiKey,
+        zoom: self.zoom
+      }
+    });
   }
 });
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -12,6 +12,7 @@
 const NodeHelper = require("node_helper");
 var request = require("request");
 const Log = require("../../js/logger");
+const buildUrl = require("build-url");
 
 module.exports = NodeHelper.create({
   start: function () {
@@ -21,11 +22,19 @@ module.exports = NodeHelper.create({
 
   getData: function () {
     var self = this;
-    var myUrl = this.config.apiBase + this.config.apiKey + this.config.apiQuery;
+
+    var url = buildUrl("https://www.teslafi.com", {
+      path: "feed.php",
+      queryParams: {
+        token: self.config.apiKey,
+        command: self.config.apiCommand
+      }
+    });
+
     Log.info("TeslaFi sending request");
     request(
       {
-        url: myUrl,
+        url: url,
         method: "GET",
         headers: { TeslaFi_API_TOKEN: this.config.apiKey }
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "prettier": {
     "trailingComma": "none"
   },
-  "dependencies": {},
+  "dependencies": {
+    "build-url": "^6.0.1"
+  },
   "devDependencies": {
     "eslint": "^7.9.0",
     "prettier": "^2.1.2",


### PR DESCRIPTION
Fixes #27 

What it says on the tin! Migrated to using an external library for URL building. Updated README with appropriate new installation instructions. Modified some of the default configuration as it doesn't make sense for the base URL and path to be modifiable. 