### PR TITLE
Allow different Tesla data sources

### DIFF
--- a/DataSource.js
+++ b/DataSource.js
@@ -8,11 +8,12 @@ var DataSource = Class.extend({
   // Called when this provider is loaded, provides a copy of the configuration of this provider only
   init: function (config) {
     this.config = config;
-    this.helper = null;
+    this.callback = null;
   },
   
-  setHelper: function (helper) {
-    this.helper = helper;
+  setCallback: function (callback) {
+    Log.info("Received callback function: " + callback)
+    this.callback = callback;
   },
 
   // Called when the main module is started
@@ -21,7 +22,6 @@ var DataSource = Class.extend({
 
   // Called when we want to get new data from TeslaFi
   // This should be overridden in any sub-classes
-  // 'helper' is a copy of the node_helper object for sending data back
   fetchData: function () {}
 });
 

--- a/DataSource.js
+++ b/DataSource.js
@@ -8,7 +8,7 @@ class DataSource {
     this.config = config;
     this.callback = null;
   }
-  
+
   // Called when the main module is started
   // Throws an exception if the configuration is not correct
   start() {}

--- a/DataSource.js
+++ b/DataSource.js
@@ -15,7 +15,7 @@ class DataSource {
 
   // Called when we want to get new data from TeslaFi
   // This should be overridden in any sub-classes
-  fetchData() {}
+  fetchData(callback) {}
 }
 
 module.exports = DataSource;

--- a/DataSource.js
+++ b/DataSource.js
@@ -1,0 +1,37 @@
+/*
+ * This is the base class for any extension that provides a source for data
+ */
+
+var DataSource = Class.extend({
+  config: null, // Copy of the module configuration
+  context: null, // Reference to the module itself, for any function access
+
+  // Called when this provider is loaded, provides a copy of the configuration of the module
+  init: function (context) {
+    this.config = context.config;
+    this.context = context;
+    this.helper = null;
+  },
+  
+  setHelper: function (helper) {
+    this.helper = helper;
+  },
+
+  // Called when the main module is started
+  // Throws an exception if the configuration is not correct
+  start: function () {},
+
+  // Called when we want to get new data from TeslaFi
+  // This should be overridden in any sub-classes
+  // 'helper' is a copy of the node_helper object for sending data back
+  fetchData: function () {}
+});
+
+// Collection of all DataItemProviders that are registered with the module
+DataSource.providers = [];
+
+// Register a new DataItemProvider with the module
+DataSource.register = function (identifier, details) {
+  DataSource.providers[identifier.toLowerCase()] =
+    DataSource.extend(details);
+};

--- a/DataSource.js
+++ b/DataSource.js
@@ -3,13 +3,11 @@
  */
 
 var DataSource = Class.extend({
-  config: null, // Copy of the module configuration
-  context: null, // Reference to the module itself, for any function access
+  config: null, // Copy of the provider configuration
 
-  // Called when this provider is loaded, provides a copy of the configuration of the module
-  init: function (context) {
-    this.config = context.config;
-    this.context = context;
+  // Called when this provider is loaded, provides a copy of the configuration of this provider only
+  init: function (config) {
+    this.config = config;
     this.helper = null;
   },
   

--- a/DataSource.js
+++ b/DataSource.js
@@ -2,34 +2,18 @@
  * This is the base class for any extension that provides a source for data
  */
 
-var DataSource = Class.extend({
-  config: null, // Copy of the provider configuration
-
+class DataSource {
   // Called when this provider is loaded, provides a copy of the configuration of this provider only
-  init: function (config) {
+  constructor(config) {
     this.config = config;
     this.callback = null;
-  },
+  }
   
-  setCallback: function (callback) {
-    Log.info("Received callback function: " + callback)
-    this.callback = callback;
-  },
-
   // Called when the main module is started
   // Throws an exception if the configuration is not correct
-  start: function () {},
+  start() {}
 
   // Called when we want to get new data from TeslaFi
   // This should be overridden in any sub-classes
-  fetchData: function () {}
-});
-
-// Collection of all DataItemProviders that are registered with the module
-DataSource.providers = [];
-
-// Register a new DataItemProvider with the module
-DataSource.register = function (identifier, details) {
-  DataSource.providers[identifier.toLowerCase()] =
-    DataSource.extend(details);
-};
+  fetchData() {}
+}

--- a/DataSource.js
+++ b/DataSource.js
@@ -17,3 +17,5 @@ class DataSource {
   // This should be overridden in any sub-classes
   fetchData() {}
 }
+
+module.exports = DataSource;

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -50,7 +50,7 @@ Module.register("MMM-TeslaFi", {
     return [
       "moment.js",
       this.file("node_modules/build-url/src/build-url.js"),
-      
+
       this.file("DataItemProvider.js"),
       this.file("dataitems/battery.js"),
       this.file("dataitems/charge.js"),
@@ -82,7 +82,7 @@ Module.register("MMM-TeslaFi", {
 
     this.resetDomUpdate();
   },
-  
+
   resetDomUpdate: function () {
     var self = this;
     // Reset any previously allocated timer to avoid double-refreshes
@@ -92,7 +92,7 @@ Module.register("MMM-TeslaFi", {
       self.updateDom(self.config.animationSpeed);
     }, this.config.refreshInterval);
   },
-  
+
   getDom: function () {
     var wrapper = document.createElement("div");
     if (!this.loaded) {

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -50,10 +50,19 @@ Module.register("MMM-TeslaFi", {
     return [
       "moment.js",
       this.file("node_modules/build-url/src/build-url.js"),
+      
       this.file("DataItemProvider.js"),
+      this.file("dataitems/battery.js"),
+      this.file("dataitems/charge.js"),
+      this.file("dataitems/driving.js"),
+      this.file("dataitems/location.js"),
+      this.file("dataitems/range.js"),
+      this.file("dataitems/software.js"),
+      this.file("dataitems/state.js"),
+      this.file("dataitems/temperature.js"),
+      
       this.file("DataSource.js"),
-      this.file("dataitems/*.js"),
-      this.file("datasources/*.js")
+      this.file("datasources/teslafi.js")
     ];
   },
   getStyles: function () {

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -85,7 +85,7 @@ Module.register("MMM-TeslaFi", {
     }
     
     if (DataSource.providers[this.config.source.name]) {
-      this.dataSource = new DataSource.providers[this.config.source.name](this);
+      this.dataSource = new DataSource.providers[this.config.source.name](this.config.source);
       try {
         this.dataSource.start();
         this.sendSocketNotification("SOURCE", this.dataSource);

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -103,11 +103,6 @@ Module.register("MMM-TeslaFi", {
       wrapper.className = "dimmed light small";
       return wrapper;
     }
-    if (!this.dataSource) {
-      wrapper.innerHTML = "No data source configured";
-      wrapper.className = "dimmed light small";
-      return wrapper;
-    }
     if (!this.teslafiData) {
       wrapper.innerHTML = "No data";
       wrapper.className = "dimmed light small";

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -59,10 +59,7 @@ Module.register("MMM-TeslaFi", {
       this.file("dataitems/range.js"),
       this.file("dataitems/software.js"),
       this.file("dataitems/state.js"),
-      this.file("dataitems/temperature.js"),
-      
-      this.file("DataSource.js"),
-      this.file("datasources/teslafi.js")
+      this.file("dataitems/temperature.js")
     ];
   },
   getStyles: function () {

--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -76,25 +76,11 @@ Module.register("MMM-TeslaFi", {
     this.loaded = false;
     this.sendSocketNotification("CONFIG", this.config);
     this.providers = [];
-    this.dataSource = null;
 
     for (var identifier in DataItemProvider.providers) {
       this.providers[identifier] = new DataItemProvider.providers[identifier](
         this
       );
-    }
-    
-    if (DataSource.providers[this.config.source.name]) {
-      this.dataSource = new DataSource.providers[this.config.source.name](this.config.source);
-      try {
-        this.dataSource.start();
-        this.sendSocketNotification("SOURCE", this.dataSource);
-      } catch(exception) {
-        Log.error("There was an error starting data source '" + this.config.source + "' - the module will not run:");
-        Log.error(exception);
-        this.dataSource = null;
-      }
-      
     }
 
     this.resetDomUpdate();

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ You can then use the various configuration options below to customise how the mo
 | batteryDanger   | The percentage below which your battery level will highlight in red                                                   | `40`                                                |
 | batteryWarning  | The percentage below which your battery level will highlight in orange                                                | `60`                                                |
 | precision       | How many decimal places to round values (such as mileage and energy) to. Defaults to 1                                | `2`                                                 |
-| apiCommand      | The command parameter for the TeslaFi API query. See [TeslaFi](https://teslafi.com/api.php) for possible values       | `lastGoodTemp`                                      |
 | unitTemperature | The unit to use for displaying temperature. Options are 'f' (Farenheight) or 'c' (Celcius). Defaults to 'c'           | `f`                                                 |
 | unitDistance    | The unit to use for displaying distance. Options are 'miles' or 'km'. Defaults to 'miles'                             | `km`                                                |
 | items           | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
@@ -81,12 +80,15 @@ modules: [
     config: {
       source: {
         name: "teslafi",
-        apiKey: "ENTER YOUR KEY HERE"
+        apiKey: "ENTER YOUR KEY HERE",
+        apiCommand: `lastGoodTemp`
       }
     }
   }
 ];
 ```
+
+The `apiCommand` configuration variable is optional, see [TeslaFi](https://teslafi.com/api.php) for possible values.
 
 #### Tessie
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ See [Map section](#map) below for more information
 | heading                | Vehicle heading                                                                                                                  |
 | map                    | Displays current location on a map. See the [Map section](#map) for details on how to configure                                  |
 
+- Some fields may not work with certain data sources. For example - location, version and version-new will only work with TeslaFi
 - Some fields (charge-time, charge-added, charge-power) are only enabled if the vehicle is plugged in
-- Some fields (version, speed, heading) are only enabled if the vehicle is not driving
+- Some fields (version, speed, heading) are only enabled if the vehicle is (or is not) driving
 - The temperature field may not be populated if you use TeslaFi's sleep mode, which will stop this row from showing entirely. You may need to use `apiCommand: "lastGoodTemp"` if this fails to show
 - For details on TeslaFi's 'location' tags, see [TeslaFi Locations](https://teslafi.com/locations.php)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror).
 
-With this module, you can display the status of your Tesla vehicle from [TeslaFi](https://www.teslafi.com/signup.php?referred=warlrus). Many different pieces of data can be shown, such as the battery level, temperature, lock status and plenty more!
-A valid TeslaFi API key is required, the key can be requested [here](https://teslafi.com/api.php)
+With this module, you can display the status of your Tesla vehicle from [TeslaFi](https://www.teslafi.com/signup.php?referred=warlrus) or [Tessie](https://tessie.com/). Many different pieces of data can be shown, such as the battery level, temperature, lock status and plenty more!
 
 This is a partial re-write of the original MMM-TeslaFi by [f00d4tehg0dz](https://github.com/f00d4tehg0dz), which can be found [here](https://github.com/f00d4tehg0dz/MMM-TeslaFi). I have chosen to not merge this version back in as it breaks some functionality of the original module.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ modules: [
 
 #### Tessie
 
-You should obtain your access token from (Tessie.com)[https://my.tessie.com/settings/api], as well as the VIN code of the vehicle you wish to display, and configure the module as follows
+You should obtain your access token from [Tessie.com](https://my.tessie.com/settings/api), as well as the VIN code of the vehicle you wish to display, and configure the module as follows
 
 ```javascript
 modules: [

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ modules: [
     module: "MMM-TeslaFi",
     position: "top_left",
     config: {
-      apiKey: "ENTER YOUR KEY HERE"
+      source: {
+        name: "teslafi",
+        apiKey: "ENTER YOUR KEY HERE"
+      }
     }
   }
 ];
@@ -50,7 +53,7 @@ You can then use the various configuration options below to customise how the mo
 
 | Option          | Details                                                                                                               | Example                                             |
 | --------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| apiKey          | **Required** - The API key from [TeslaFi.com](https://teslafi.com/api.php)                                            | `4de3736a68714869d3e2fbda1f1b83ff`                  |
+| source          | **Required** - The source from which to pull Tesla data. See [Data Source](#data-source) below for more information   | [See below](#data-source)                           |
 | refreshInterval | The time interval (in milliseconds) at which the module contents will be updated locally                              | `1000 * 60`                                         |
 | updateInterval  | The time interval (in milliseconds) at which fresh data will be gathered from TeslaFi                                 | `1000 * 60 * 5`                                     |
 | batteryDanger   | The percentage below which your battery level will highlight in red                                                   | `40`                                                |
@@ -61,6 +64,49 @@ You can then use the various configuration options below to customise how the mo
 | unitDistance    | The unit to use for displaying distance. Options are 'miles' or 'km'. Defaults to 'miles'                             | `km`                                                |
 | items           | The rows of data you want the module to show. See list [below](#available-fields). By default will show all available | `['battery','range-estimated','locked','odometer']` |
 | dataTimeout     | How old data must be in seconds before 'data-time' is displayed. Use 0 to always show                                 | `0`                                                 |
+
+### Data Source
+
+The `source` configuration option defines which data source you want to use to pull Tesla data from. At the moment there are two available options, which are configured as shown below. Note that some data fields may not be available from some data sources due to API differences.
+
+#### TeslaFi
+
+You should obtain your API key from [TeslaFi.com](https://teslafi.com/api.php) and configure the module as follows:
+
+```javascript
+modules: [
+  {
+    module: "MMM-TeslaFi",
+    position: "top_left",
+    config: {
+      source: {
+        name: "teslafi",
+        apiKey: "ENTER YOUR KEY HERE"
+      }
+    }
+  }
+];
+```
+
+#### Tessie
+
+You should obtain your access token from (Tessie.com)[https://my.tessie.com/settings/api], as well as the VIN code of the vehicle you wish to display, and configure the module as follows
+
+```javascript
+modules: [
+  {
+    module: "MMM-TeslaFi",
+    position: "top_left",
+    config: {
+      source: {
+        name: "tessie",
+        apiKey: "ENTER YOUR ACCESS TOKEN HERE",
+        vin: "ENTER YOUR VIN HERE"
+      }
+    }
+  }
+];
+```
 
 ### Maps Configuration
 

--- a/dataitems/charge.js
+++ b/dataitems/charge.js
@@ -9,7 +9,7 @@ DataItemProvider.register("charge-time", {
   field: "Charging",
 
   onDataUpdate(data) {
-    var timeLeft = parseInt(data.time_to_full_charge)
+    var timeLeft = parseInt(data.time_to_full_charge);
     if (!data.charging_state || timeLeft === 0) {
       this.display = false;
       return;

--- a/dataitems/charge.js
+++ b/dataitems/charge.js
@@ -9,7 +9,8 @@ DataItemProvider.register("charge-time", {
   field: "Charging",
 
   onDataUpdate(data) {
-    if (!data.charging_state || data.time_to_full_charge === "0.0") {
+    var timeLeft = parseInt(data.time_to_full_charge)
+    if (!data.charging_state || timeLeft === 0) {
       this.display = false;
       return;
     } else {
@@ -55,7 +56,8 @@ DataItemProvider.register("charge-power", {
   field: "Charger Power",
 
   onDataUpdate(data) {
-    if (data.charger_power === "0") {
+    var power = parseInt(data.charger_power);
+    if (power === 0) {
       this.display = false;
       return;
     } else {

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -5,7 +5,7 @@
  */
 
 var request = require("request");
-const Log = require("../../js/logger");
+const Log = require("../../../js/logger");
 const buildUrl = require("build-url");
 
 class TeslaFi extends DataSource {

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -15,7 +15,7 @@ DataSource.register("teslafi", {
     }
   },
   
-  fetchData(helper) {
+  fetchData() {
      var url = buildUrl("https://www.teslafi.com", {
       path: "feed.php",
       queryParams: {

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -10,7 +10,7 @@ DataSource.register("teslafi", {
       this.config.source.apiCommand = "lastGood";
     }
     
-    if(!this.config.teslafi.apiKey) {
+    if(!this.config.source.apiKey) {
       throw new Exception("You must specify a TeslaFi API key");
     }
   },

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -1,0 +1,50 @@
+/*
+ * Fetch data from TeslaFi
+ *
+ * Created by Matt Dyson
+ */
+
+const NodeHelper = require("node_helper");
+var request = require("request");
+const Log = require("../../js/logger");
+const buildUrl = require("build-url");
+
+DataSource.register("teslafi", {
+  
+  start() {
+    if(this.config.source.apiCommand === null || this.config.source.apiCommand === "") {
+      this.config.source.apiCommand = "lastGood";
+    }
+    
+    if(!this.config.teslafi.apiKey) {
+      throw new Exception("You must specify a TeslaFi API key");
+    }
+  },
+  
+  fetchData(helper) {
+    var self = this;
+
+    var url = buildUrl("https://www.teslafi.com", {
+      path: "feed.php",
+      queryParams: {
+        token: self.config.source.apiKey,
+        command: self.config.source.apiCommand
+      }
+    });
+
+    Log.info("Sending request to TeslaFi");
+    request(
+      {
+        url: url,
+        method: "GET",
+        headers: { TeslaFi_API_TOKEN: this.config.source.apiKey }
+      },
+      function (error, response, body) {
+        Log.info("TeslaFi response was " + response.statusCode);
+        if (!error && response.statusCode === 200) {
+          helper.sendData(body);
+        }
+      }
+    );
+  }
+});

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -16,6 +16,8 @@ DataSource.register("teslafi", {
   },
   
   fetchData() {
+    var self =  this;
+    
      var url = buildUrl("https://www.teslafi.com", {
       path: "feed.php",
       queryParams: {
@@ -34,7 +36,7 @@ DataSource.register("teslafi", {
       function (error, response, body) {
         Log.info("TeslaFi response was " + response.statusCode);
         if (!error && response.statusCode === 200) {
-          helper.sendData(body);
+          self.callback(body);
         }
       }
     );

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -3,12 +3,6 @@
  *
  * Created by Matt Dyson
  */
-
-const NodeHelper = require("node_helper");
-var request = require("request");
-const Log = require("../../js/logger");
-const buildUrl = require("build-url");
-
 DataSource.register("teslafi", {
   
   start() {

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -18,7 +18,7 @@ class TeslaFi extends DataSource {
     }
 
     if (!this.config.apiKey) {
-      throw new Exception("You must specify a TeslaFi API key");
+      throw new Error("You must specify a TeslaFi API key");
     }
   }
 

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -6,23 +6,21 @@
 DataSource.register("teslafi", {
   
   start() {
-    if(this.config.source.apiCommand === null || this.config.source.apiCommand === "") {
-      this.config.source.apiCommand = "lastGood";
+    if(this.config.apiCommand === null || this.config.apiCommand === "") {
+      this.config.apiCommand = "lastGood";
     }
     
-    if(!this.config.source.apiKey) {
+    if(!this.config.apiKey) {
       throw new Exception("You must specify a TeslaFi API key");
     }
   },
   
   fetchData(helper) {
-    var self = this;
-
-    var url = buildUrl("https://www.teslafi.com", {
+     var url = buildUrl("https://www.teslafi.com", {
       path: "feed.php",
       queryParams: {
-        token: self.config.source.apiKey,
-        command: self.config.source.apiCommand
+        token: this.config.apiKey,
+        command: this.config.apiCommand
       }
     });
 
@@ -31,7 +29,7 @@ DataSource.register("teslafi", {
       {
         url: url,
         method: "GET",
-        headers: { TeslaFi_API_TOKEN: this.config.source.apiKey }
+        headers: { TeslaFi_API_TOKEN: this.config.apiKey }
       },
       function (error, response, body) {
         Log.info("TeslaFi response was " + response.statusCode);

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -22,8 +22,9 @@ class TeslaFi extends DataSource {
     }
   }
   
-  fetchData() {
-    var self =  this;
+  fetchData(callback) {
+     var self =  this;
+     self.callback = callback
     
      var url = buildUrl("https://www.teslafi.com", {
       path: "feed.php",

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -12,21 +12,21 @@ const DataSource = require("../DataSource");
 class TeslaFi extends DataSource {
   constructor(config) {
     super(config);
-    
-    if(this.config.apiCommand === null || this.config.apiCommand === "") {
+
+    if (this.config.apiCommand === null || this.config.apiCommand === "") {
       this.config.apiCommand = "lastGood";
     }
-    
-    if(!this.config.apiKey) {
+
+    if (!this.config.apiKey) {
       throw new Exception("You must specify a TeslaFi API key");
     }
   }
-  
+
   fetchData(callback) {
-     var self =  this;
-     self.callback = callback
-    
-     var url = buildUrl("https://www.teslafi.com", {
+    var self = this;
+    self.callback = callback;
+
+    var url = buildUrl("https://www.teslafi.com", {
       path: "feed.php",
       queryParams: {
         token: this.config.apiKey,

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -3,9 +3,10 @@
  *
  * Created by Matt Dyson
  */
-DataSource.register("teslafi", {
-  
-  start() {
+class TeslaFi extends DataSource {
+  constructor(config) {
+    super(config);
+    
     if(this.config.apiCommand === null || this.config.apiCommand === "") {
       this.config.apiCommand = "lastGood";
     }
@@ -13,7 +14,7 @@ DataSource.register("teslafi", {
     if(!this.config.apiKey) {
       throw new Exception("You must specify a TeslaFi API key");
     }
-  },
+  }
   
   fetchData() {
     var self =  this;
@@ -41,4 +42,4 @@ DataSource.register("teslafi", {
       }
     );
   }
-});
+}

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -7,6 +7,7 @@
 var request = require("request");
 const Log = require("../../../js/logger");
 const buildUrl = require("build-url");
+const DataSource = require("../DataSource");
 
 class TeslaFi extends DataSource {
   constructor(config) {

--- a/datasources/teslafi.js
+++ b/datasources/teslafi.js
@@ -3,6 +3,11 @@
  *
  * Created by Matt Dyson
  */
+
+var request = require("request");
+const Log = require("../../js/logger");
+const buildUrl = require("build-url");
+
 class TeslaFi extends DataSource {
   constructor(config) {
     super(config);
@@ -43,3 +48,5 @@ class TeslaFi extends DataSource {
     );
   }
 }
+
+module.exports = TeslaFi;

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -48,7 +48,7 @@ class Tessie extends DataSource {
          Log.info("Tessie response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
            
-           var vehicle = response.results[0]['last_state'];
+           var vehicle = body.results[0]['last_state'];
            Log.info("Vehicle found: " + vehicle);
            
            var parsed = {};

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -14,11 +14,11 @@ class Tessie extends DataSource {
     super(config);
 
     if (!this.config.apiKey) {
-      throw new Exception("You must specify a Tessie API key");
+      throw new Error("You must specify a Tessie API key");
     }
 
     if (!this.config.vin) {
-      throw new Exception("You must specify the VIN of your vehicle");
+      throw new Error("You must specify the VIN of your vehicle");
     }
   }
 

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -48,14 +48,13 @@ class Tessie extends DataSource {
          Log.info("TeslaFi response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
            
-           var json = JSON.parse(response);
            var parsed = {};
            
            for(header in ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']) {
              Log.info("Entering " + header);
-             for(entry in json.results[0].last_state[header]) {
-               Log.info( " - " + entry + " => " + json.results[0].last_state[header][entry]);
-               parsed[entry] = json.results[0].last_state[header][entry];
+             for(entry in response.results[0].last_state[header]) {
+               Log.info( " - " + entry + " => " + response.results[0].last_state[header][entry]);
+               parsed[entry] = response.results[0].last_state[header][entry];
              }
            }
            

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -65,7 +65,7 @@ class Tessie extends DataSource {
            
            
            // Attempt to recreate the useful TeslaFi 'carState' variable
-           var carState = null;
+           var carState = 'Idling';
            
            if(parsed['charging_state'] === "Complete") {
              carState = "Idling";
@@ -77,9 +77,7 @@ class Tessie extends DataSource {
              carState = "Sentry";
            }
            
-           if(carState !== null) {
-             parsed['carState'] = carState;  
-           }
+           parsed['carState'] = carState;  
            
            var json = JSON.stringify(parsed);
            

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -45,30 +45,25 @@ class Tessie extends DataSource {
          }
        },
        function (error, response, body) {
-         Log.info("Tessie response was code " + response.statusCode + ": " + body);
+         Log.info("Tessie response was code " + response.statusCode);
          if (!error && response.statusCode === 200) {
            
            body = JSON.parse(body);
            
            var parsed = {};
            
-           for(var header in body) {
-             Log.info("Entering " + header + ", which is a " + typeof header);
-             
+           // Flatten Tessie response into one-dimensional object
+           for(var header in body) {             
              if(typeof body[header] === "object") {
                for(var entry in body[header]) {
-                 Log.info( " - " + entry + " => " + body[header][entry]);
                  parsed[entry] = body[header][entry];
                }  
              } else {
-               Log.info(" - " + header + " => " + body[header]);
                parsed[header] = body[header];
              }
            }
            
            var json = JSON.stringify(parsed);
-           
-           Log.info("Final response from Tessie:" + json);
            
            self.callback(json);
          }

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -47,19 +47,14 @@ class Tessie extends DataSource {
        function (error, response, body) {
          Log.info("Tessie response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
-           Log.info("Body: " + body);
-           
-           var vehicle = body.results[0]['last_state'];
-           Log.info("Vehicle found: " + vehicle);
-           
            var parsed = {};
            
            var headers = ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']
            for(var header in headers) {
              Log.info("Entering " + headers[header]);
-             for(var entry in vehicle[headers[header]]) {
-               Log.info( " - " + entry + " => " + vehicle[headers[header]][entry]);
-               parsed[entry] = vehicle[headers[header]][entry];
+             for(var entry in body[headers[header]]) {
+               Log.info( " - " + entry + " => " + body[headers[header]][entry]);
+               parsed[entry] = body[headers[header]][entry];
              }
            }
            

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -47,6 +47,9 @@ class Tessie extends DataSource {
        function (error, response, body) {
          Log.info("Tessie response was code " + response.statusCode + ": " + body);
          if (!error && response.statusCode === 200) {
+           
+           body = JSON.parse(body);
+           
            var parsed = {};
            
            for(var header in body) {

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -63,6 +63,24 @@ class Tessie extends DataSource {
              }
            }
            
+           
+           // Attempt to recreate the useful TeslaFi 'carState' variable
+           var carState = null;
+           
+           if(parsed['charging_state'] === "Complete") {
+             carState = "Idling";
+           } else if(parsed['charging_state'] === "Charging") {
+             carState = "Charging";
+           } else if(parsed['shift_state'] === "D") {
+             carState = "Driving";
+           } else if(parsed['sentry_mode'] === true) {
+             carState = "Sentry";
+           }
+           
+           if(carState !== null) {
+             parsed['carState'] = carState;  
+           }
+           
            var json = JSON.stringify(parsed);
            
            self.callback(json);

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -48,14 +48,17 @@ class Tessie extends DataSource {
          Log.info("Tessie response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
            
+           var vehicle = response.results[0]['last_state'];
+           Log.info("Vehicle found: " + vehicle);
+           
            var parsed = {};
            
            var headers = ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']
            for(var header in headers) {
              Log.info("Entering " + headers[header]);
-             for(var entry in response.results[0].last_state[headers[header]]) {
-               Log.info( " - " + entry + " => " + response.results[0].last_state[headers[header]][entry]);
-               parsed[entry] = response.results[0].last_state[headers[header]][entry];
+             for(var entry in vehicle[headers[header]]) {
+               Log.info( " - " + entry + " => " + vehicle[headers[header]][entry]);
+               parsed[entry] = vehicle[headers[header]][entry];
              }
            }
            

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -1,0 +1,57 @@
+/*
+ * Fetch data from Tessie
+ *
+ * Created by Matt Dyson
+ */
+
+var request = require("request");
+const Log = require("../../../js/logger");
+const buildUrl = require("build-url");
+const DataSource = require("../DataSource");
+const sdk = require('api')('@tessie/v2.0#3vnlia9l48orn1r');
+
+class Tessie extends DataSource {
+  constructor(config) {
+    super(config);
+    
+    if(!this.config.apiKey) {
+      throw new Exception("You must specify a Tessie API key");
+    }
+    
+    if(!this.config.vin) {
+      throw new Exception("You must specify the VIN of your vehicle");
+    }
+    
+    sdk.auth(this.config.apiKey);
+    
+  }
+  
+  fetchData(callback) {
+     var self =  this;
+     self.callback = callback
+     
+     Log.info("Sending request to Tessie");
+     sdk.getState({use_cache: 'true', vin: this.config.vin})
+     .then(function(result) {
+       Log.info("Tessie response received");
+       
+       var json = JSON.parse(result);
+       var response = {};
+       
+       for(header in ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']) {
+         Log.info("Entering " + header);
+         for(entry in json.results[0].last_state[header]) {
+           Log.info( " - " + entry + " => " + json.results[0].last_state[header][entry]);
+           response[entry] = json.results[0].last_state[header][entry];
+         }
+       }
+       
+       Log.info("Final response from Tessie:" + response);
+       
+       self.callback(response);
+     })
+     .catch(err => Log.error(err));
+  }
+}
+
+module.exports = Tessie;

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -21,8 +21,6 @@ class Tessie extends DataSource {
       throw new Exception("You must specify the VIN of your vehicle");
     }
     
-    sdk.auth(this.config.apiKey);
-    
   }
   
   fetchData(callback) {

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -48,20 +48,20 @@ class Tessie extends DataSource {
          Log.info("TeslaFi response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
            
-           var json = JSON.parse(result);
-           var response = {};
+           var json = JSON.parse(response);
+           var parsed = {};
            
            for(header in ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']) {
              Log.info("Entering " + header);
              for(entry in json.results[0].last_state[header]) {
                Log.info( " - " + entry + " => " + json.results[0].last_state[header][entry]);
-               response[entry] = json.results[0].last_state[header][entry];
+               parsed[entry] = json.results[0].last_state[header][entry];
              }
            }
            
-           Log.info("Final response from Tessie:" + response);
+           Log.info("Final response from Tessie:" + parsed);
            
-           self.callback(response);
+           self.callback(parsed);
          }
        }
      );

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -47,6 +47,7 @@ class Tessie extends DataSource {
        function (error, response, body) {
          Log.info("Tessie response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
+           Log.info("Body: " + body);
            
            var vehicle = body.results[0]['last_state'];
            Log.info("Vehicle found: " + vehicle);

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -12,79 +12,76 @@ const DataSource = require("../DataSource");
 class Tessie extends DataSource {
   constructor(config) {
     super(config);
-    
-    if(!this.config.apiKey) {
+
+    if (!this.config.apiKey) {
       throw new Exception("You must specify a Tessie API key");
     }
-    
-    if(!this.config.vin) {
+
+    if (!this.config.vin) {
       throw new Exception("You must specify the VIN of your vehicle");
     }
-    
   }
-  
-  fetchData(callback) {
-     var self =  this;
-     self.callback = callback;
-     
-     var url = buildUrl("https://api.tessie.com", {
-       path: "/" + this.config.vin + "/state",
-       queryParams: {
-         use_cache: true
-       }
-     });
 
-     Log.info("Sending request to Tessie");
-     request(
-       {
-         url: url,
-         method: "GET",
-         headers: {
-           "Authorization": "Bearer " + this.config.apiKey,
-           "Accept": ""
-         }
-       },
-       function (error, response, body) {
-         Log.info("Tessie response was code " + response.statusCode);
-         if (!error && response.statusCode === 200) {
-           
-           body = JSON.parse(body);
-           
-           var parsed = {};
-           
-           // Flatten Tessie response into one-dimensional object
-           for(var header in body) {             
-             if(typeof body[header] === "object") {
-               for(var entry in body[header]) {
-                 parsed[entry] = body[header][entry];
-               }  
-             } else {
-               parsed[header] = body[header];
-             }
-           }
-           
-           
-           // Attempt to recreate the useful TeslaFi 'carState' variable
-           var carState = 'Idling';
-           
-           if(parsed['charging_state'] === "Complete") {
-             carState = "Idling";
-           } else if(parsed['charging_state'] === "Charging") {
-             carState = "Charging";
-           } else if(parsed['shift_state'] === "D") {
-             carState = "Driving";
-           } else if(parsed['sentry_mode'] === true) {
-             carState = "Sentry";
-           }
-           
-           parsed['carState'] = carState;  
-           
-           var json = JSON.stringify(parsed);
-           
-           self.callback(json);
-         }
-       }
-     );
+  fetchData(callback) {
+    var self = this;
+    self.callback = callback;
+
+    var url = buildUrl("https://api.tessie.com", {
+      path: "/" + this.config.vin + "/state",
+      queryParams: {
+        use_cache: true
+      }
+    });
+
+    Log.info("Sending request to Tessie");
+    request(
+      {
+        url: url,
+        method: "GET",
+        headers: {
+          Authorization: "Bearer " + this.config.apiKey,
+          Accept: ""
+        }
+      },
+      function (error, response, body) {
+        Log.info("Tessie response was code " + response.statusCode);
+        if (!error && response.statusCode === 200) {
+          body = JSON.parse(body);
+
+          var parsed = {};
+
+          // Flatten Tessie response into one-dimensional object
+          for (var header in body) {
+            if (typeof body[header] === "object") {
+              for (var entry in body[header]) {
+                parsed[entry] = body[header][entry];
+              }
+            } else {
+              parsed[header] = body[header];
+            }
+          }
+
+          // Attempt to recreate the useful TeslaFi 'carState' variable
+          var carState = "Idling";
+
+          if (parsed["charging_state"] === "Complete") {
+            carState = "Idling";
+          } else if (parsed["charging_state"] === "Charging") {
+            carState = "Charging";
+          } else if (parsed["shift_state"] === "D") {
+            carState = "Driving";
+          } else if (parsed["sentry_mode"] === true) {
+            carState = "Sentry";
+          }
+
+          parsed["carState"] = carState;
+
+          var json = JSON.stringify(parsed);
+
+          self.callback(json);
+        }
+      }
+    );
   }
 }
 

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -45,7 +45,7 @@ class Tessie extends DataSource {
          }
        },
        function (error, response, body) {
-         Log.info("Tessie response was " + response.statusCode);
+         Log.info("Tessie response was code " + response.statusCode + ": " + body);
          if (!error && response.statusCode === 200) {
            var parsed = {};
            

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -45,14 +45,14 @@ class Tessie extends DataSource {
          }
        },
        function (error, response, body) {
-         Log.info("TeslaFi response was " + response.statusCode);
+         Log.info("Tessie response was " + response.statusCode);
          if (!error && response.statusCode === 200) {
            
            var parsed = {};
            
-           for(header in ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']) {
+           for(var header in ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']) {
              Log.info("Entering " + header);
-             for(entry in response.results[0].last_state[header]) {
+             for(var entry in response.results[0].last_state[header]) {
                Log.info( " - " + entry + " => " + response.results[0].last_state[header][entry]);
                parsed[entry] = response.results[0].last_state[header][entry];
              }

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -58,9 +58,11 @@ class Tessie extends DataSource {
              }
            }
            
-           Log.info("Final response from Tessie:" + parsed);
+           var json = JSON.stringify(parsed);
            
-           self.callback(parsed);
+           Log.info("Final response from Tessie:" + json);
+           
+           self.callback(json);
          }
        }
      );

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -49,12 +49,17 @@ class Tessie extends DataSource {
          if (!error && response.statusCode === 200) {
            var parsed = {};
            
-           var headers = ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']
-           for(var header in headers) {
-             Log.info("Entering " + headers[header]);
-             for(var entry in body[headers[header]]) {
-               Log.info( " - " + entry + " => " + body[headers[header]][entry]);
-               parsed[entry] = body[headers[header]][entry];
+           for(var header in body) {
+             Log.info("Entering " + header + ", which is a " + typeof header);
+             
+             if(typeof body[header] === "object") {
+               for(var entry in body[header]) {
+                 Log.info( " - " + entry + " => " + body[header][entry]);
+                 parsed[entry] = body[header][entry];
+               }  
+             } else {
+               Log.info(" - " + header + " => " + body[header]);
+               parsed[header] = body[header];
              }
            }
            

--- a/datasources/tessie.js
+++ b/datasources/tessie.js
@@ -50,11 +50,12 @@ class Tessie extends DataSource {
            
            var parsed = {};
            
-           for(var header in ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']) {
-             Log.info("Entering " + header);
-             for(var entry in response.results[0].last_state[header]) {
-               Log.info( " - " + entry + " => " + response.results[0].last_state[header][entry]);
-               parsed[entry] = response.results[0].last_state[header][entry];
+           var headers = ['charge_state', 'climate_state', 'drive_state', 'gui_settings', 'vehicle_config', 'vehicle_state']
+           for(var header in headers) {
+             Log.info("Entering " + headers[header]);
+             for(var entry in response.results[0].last_state[headers[header]]) {
+               Log.info( " - " + entry + " => " + response.results[0].last_state[headers[header]][entry]);
+               parsed[entry] = response.results[0].last_state[headers[header]][entry];
              }
            }
            

--- a/node_helper.js
+++ b/node_helper.js
@@ -32,7 +32,7 @@ module.exports = NodeHelper.create({
     Log.info("TeslaFi fetching data from source: " + this.source.config.name);
     this.source.fetchData(function(response) {
       Log.info("Received data: " + response);
-      self.sendSocketNotification("DATA", data);
+      self.sendSocketNotification("DATA", response);
     });
     
     setTimeout(function () {

--- a/node_helper.js
+++ b/node_helper.js
@@ -27,50 +27,57 @@ module.exports = NodeHelper.create({
 
   getData: function () {
     var self = this;
-    
-    if(!this.started) { return; }
-    
+
+    if (!this.started) {
+      return;
+    }
+
     Log.info("TeslaFi fetching data from source: " + this.source.config.name);
-    this.source.fetchData(function(response) {
+    this.source.fetchData(function (response) {
       Log.info("Received data: " + response);
       self.sendSocketNotification("DATA", response);
     });
-    
+
     setTimeout(function () {
       self.getData();
     }, this.config.updateInterval);
   },
 
   socketNotificationReceived: function (notification, payload) {
-    if(payload === null) {
+    if (payload === null) {
       return;
     }
-    
-    switch(notification) {
-    case "CONFIG":
-      if(this.config !== null) { return; }
-      
-      Log.info("TeslaFi received configuration");
-      this.config = payload;
-      
-      switch(this.config.source.name.toLowerCase()) {
-      case "teslafi":
-        this.source = new TeslaFi(this.config.source);
-        break;
-        
-      case "tessie":
-        this.source = new Tessie(this.config.source);
-        break;
-        
-      default:
-        Log.error("Unknown source provided for Tesla data: " + this.config.source.name);
-        break;
-      }
 
-      break; // End CONFIG notification
+    switch (notification) {
+      case "CONFIG":
+        if (this.config !== null) {
+          return;
+        }
+
+        Log.info("TeslaFi received configuration");
+        this.config = payload;
+
+        switch (this.config.source.name.toLowerCase()) {
+          case "teslafi":
+            this.source = new TeslaFi(this.config.source);
+            break;
+
+          case "tessie":
+            this.source = new Tessie(this.config.source);
+            break;
+
+          default:
+            Log.error(
+              "Unknown source provided for Tesla data: " +
+                this.config.source.name
+            );
+            break;
+        }
+
+        break; // End CONFIG notification
     }
-    
-    if(this.config !== null && this.source !== null && !this.started) {
+
+    if (this.config !== null && this.source !== null && !this.started) {
       Log.info("TeslaFi helper starting");
       this.sendSocketNotification("STARTED", true);
       this.started = true;

--- a/node_helper.js
+++ b/node_helper.js
@@ -45,11 +45,15 @@ module.exports = NodeHelper.create({
     
     switch(notification) {
     case "CONFIG":
+      if(this.config !== null) { return; }
+      
       Log.info("TeslaFi received configuration");
       this.config = payload;
       break;
       
     case "SOURCE":
+      if(this.source !== null) { return; }
+      
       Log.info("TeslaFi received data source: " + payload.config.name);
       this.source = payload;
       this.source.setHelper(this);

--- a/node_helper.js
+++ b/node_helper.js
@@ -57,7 +57,7 @@ module.exports = NodeHelper.create({
       
       Log.info("TeslaFi received data source: " + payload.config.name);
       this.source = payload;
-      this.source.setHelper(this);
+      this.source.setCallback(this.sendData);
       break;
     }
     

--- a/node_helper.js
+++ b/node_helper.js
@@ -30,16 +30,14 @@ module.exports = NodeHelper.create({
     if(!this.started) { return; }
     
     Log.info("TeslaFi fetching data from source: " + this.source.config.name);
-    this.source.fetchData();
+    this.source.fetchData(function(response) {
+      Log.info("Received data: " + response);
+      self.sendSocketNotification("DATA", data);
+    });
     
     setTimeout(function () {
       self.getData();
     }, this.config.updateInterval);
-  },
-  
-  sendData: function (data) {
-    Log.info("TeslaFi sending data");
-    this.sendSocketNotification("DATA", data);
   },
 
   socketNotificationReceived: function (notification, payload) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -50,6 +50,7 @@ module.exports = NodeHelper.create({
     }
     
     if(this.config !== null && this.source !== null && !this.started) {
+      Log.info("TeslaFi helper starting");
       this.sendSocketNotification("STARTED", true);
       this.getData();
       this.started = true;

--- a/node_helper.js
+++ b/node_helper.js
@@ -16,6 +16,7 @@ const buildUrl = require("build-url");
 
 const DataSource = require("./DataSource");
 const TeslaFi = require("./datasources/teslafi");
+const Tessie = require("./datasources/tessie");
 
 module.exports = NodeHelper.create({
   start: function () {
@@ -55,6 +56,10 @@ module.exports = NodeHelper.create({
       switch(this.config.source.name.toLowerCase()) {
       case "teslafi":
         this.source = new TeslaFi(this.config.source);
+        break;
+        
+      case "tessie":
+        this.source = new Tessie(this.config.source);
         break;
         
       default:

--- a/node_helper.js
+++ b/node_helper.js
@@ -22,6 +22,9 @@ module.exports = NodeHelper.create({
   },
 
   getData: function () {
+    
+    if(!this.started) { return; }
+    
     Log.info("TeslaFi fetching data from source");
     this.source.fetchData();
     
@@ -36,6 +39,10 @@ module.exports = NodeHelper.create({
   },
 
   socketNotificationReceived: function (notification, payload) {
+    if(payload === null) {
+      return;
+    }
+    
     switch(notification) {
     case "CONFIG":
       Log.info("TeslaFi received configuration");
@@ -43,7 +50,7 @@ module.exports = NodeHelper.create({
       break;
       
     case "SOURCE":
-      Log.info("TeslaFi received data source");
+      Log.info("TeslaFi received data source: " + payload.config.name);
       this.source = payload;
       this.source.setHelper(this);
       break;
@@ -52,8 +59,8 @@ module.exports = NodeHelper.create({
     if(this.config !== null && this.source !== null && !this.started) {
       Log.info("TeslaFi helper starting");
       this.sendSocketNotification("STARTED", true);
-      this.getData();
       this.started = true;
+      this.getData();
     }
   }
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -22,10 +22,11 @@ module.exports = NodeHelper.create({
   },
 
   getData: function () {
+    var self = this;
     
     if(!this.started) { return; }
     
-    Log.info("TeslaFi fetching data from source");
+    Log.info("TeslaFi fetching data from source: " + this.source.config.name);
     this.source.fetchData();
     
     setTimeout(function () {

--- a/node_helper.js
+++ b/node_helper.js
@@ -14,6 +14,9 @@ var request = require("request");
 const Log = require("../../js/logger");
 const buildUrl = require("build-url");
 
+const DataSource = require("DataSource");
+const TeslaFi = require("./datasources/teslafi");
+
 module.exports = NodeHelper.create({
   start: function () {
     this.started = false;
@@ -50,15 +53,18 @@ module.exports = NodeHelper.create({
       
       Log.info("TeslaFi received configuration");
       this.config = payload;
-      break;
       
-    case "SOURCE":
-      if(this.source !== null) { return; }
-      
-      Log.info("TeslaFi received data source: " + payload.config.name);
-      this.source = payload;
-      this.source.setCallback(this.sendData);
-      break;
+      switch(this.config.source.name.toLowerCase()) {
+      case "teslafi":
+        this.source = new TeslaFi(this.config.source);
+        break;
+        
+      default:
+        Log.error("Unknown source provided for Tesla data: " + this.config.source.name);
+        break;
+      }
+
+      break; // End CONFIG notification
     }
     
     if(this.config !== null && this.source !== null && !this.started) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -14,7 +14,7 @@ var request = require("request");
 const Log = require("../../js/logger");
 const buildUrl = require("build-url");
 
-const DataSource = require("DataSource");
+const DataSource = require("./DataSource");
 const TeslaFi = require("./datasources/teslafi");
 
 module.exports = NodeHelper.create({

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "trailingComma": "none"
   },
   "dependencies": {
-    "api": "^4.5.2",
     "build-url": "^6.0.1",
     "request": "^2.88.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "trailingComma": "none"
   },
   "dependencies": {
+    "api": "^4.5.2",
     "build-url": "^6.0.1",
     "request": "^2.88.2"
   },


### PR DESCRIPTION
As per a request from a user, I've completed work to allow data to be fetched from different sources, rather than hard-coding TeslaFi into `node_helper.js`. As of this merge, there is now the option to pull from either TelsaFi or Tessie, with the framework in place to allow other sources to be added in future if desired.

Next up is working on renaming the module to something different, including an update of `MMM-TeslaFi.js` to remove references to TeslaFi. 

Fixes #35 